### PR TITLE
Fix responsive image src/srcset selection

### DIFF
--- a/src/components/PostsComponent.astro
+++ b/src/components/PostsComponent.astro
@@ -6,7 +6,7 @@ import {
   AllowedPostTags,
   buildCategoryPath,
   buildPostPath,
-  buildResponsiveSrcSet,
+  getResponsiveImage,
   getPostsByLang,
   isPostTag,
   sortPostsByDateDesc,
@@ -90,7 +90,10 @@ const pageDescriptions = {
       ) : (
         posts.map((post) => {
           const thumbnails = post.data.thumbnails ?? [];
-          const thumbnailsSrcSet = buildResponsiveSrcSet(thumbnails);
+          const { src: thumbnailSrc, srcset: thumbnailsSrcSet } = getResponsiveImage(
+            thumbnails
+          );
+          const fallbackSrc = post.data.images?.[0] ?? "";
 
           return (
             <article class="flex w-full flex-col sm:flex-row md:flex-row lg:flex-row">
@@ -99,7 +102,7 @@ const pageDescriptions = {
                   srcset={thumbnailsSrcSet || undefined}
                   sizes="(min-width: 768px) 50vw, 100vw"
                   class="h-full w-full rounded-xl object-cover"
-                  src={thumbnails[0] ?? post.data.images?.[0]}
+                  src={thumbnailSrc || fallbackSrc}
                   alt={post.data.title}
                 />
               </a>

--- a/src/components/hero.svelte
+++ b/src/components/hero.svelte
@@ -1,6 +1,16 @@
 <script lang="ts">
+  import { getResponsiveImage } from "../utils/postUtils";
+
   export let title = "";
   export let homeHref = "/en";
+
+  const heroImages = [
+    "https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fhero.jpg?alt=media&token=6b0b5a43-9fa0-4d13-831f-4e6dc7f8d912",
+    "https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fthumbnail_half_hero.jpg?alt=media&token=152ea20f-a578-4e4c-943a-066964f69069",
+    "https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fthumbnail_med_hero.jpg?alt=media&token=0eeb83bc-9663-45fb-bd5f-a88cfff38868",
+    "https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fthumbnail_low_hero.jpg?alt=media&token=7fbd689b-5d5b-4093-9f3f-9acfd854a043",
+  ];
+  const { src: heroSrc, srcset: heroSrcSet } = getResponsiveImage(heroImages);
 </script>
 
 <div>
@@ -8,9 +18,9 @@
     <img
       class="h-[40vh] w-full object-cover"
       sizes="100vw"
-      srcset="https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fthumbnail_half_hero.jpg?alt=media&token=152ea20f-a578-4e4c-943a-066964f69069 1200w, https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fthumbnail_med_hero.jpg?alt=media&token=0eeb83bc-9663-45fb-bd5f-a88cfff38868 800w, https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fthumbnail_low_hero.jpg?alt=media&token=7fbd689b-5d5b-4093-9f3f-9acfd854a043 400w"
+      srcset={heroSrcSet}
       draggable="false"
-      src="https://firebasestorage.googleapis.com/v0/b/dashboard-blogs-app.appspot.com/o/images%2FThzROsREBLP9kFuUvCnohZ2IABw2%2Fhero.jpg?alt=media&token=6b0b5a43-9fa0-4d13-831f-4e6dc7f8d912"
+      src={heroSrc}
       alt={title ? `${title} hero banner` : "Developer blog hero banner"}
     />
     <a

--- a/src/components/smallPost.svelte
+++ b/src/components/smallPost.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { getResponsiveImage } from "../utils/postUtils";
+
   export let title = "";
   export let subtitle = "";
   export let categories: string[] = [];
@@ -6,13 +8,7 @@
   export let lang = "en";
   export let thumbnails: string[] = [];
 
-  const widths = [1200, 900, 600, 400];
-  const thumbnailsSrcSet = thumbnails
-    .map((thumbnail, index) => {
-      const width = widths[index] ?? widths[widths.length - 1];
-      return `${thumbnail} ${width}w`;
-    })
-    .join(", ");
+  const { src: thumbnailSrc, srcset: thumbnailsSrcSet } = getResponsiveImage(thumbnails);
 </script>
 
 <div class="h-auto w-full">
@@ -20,7 +16,7 @@
     <img
       srcset={thumbnailsSrcSet || undefined}
       sizes="(min-width: 1024px) 33vw, (min-width: 640px) 50vw, 100vw"
-      src={thumbnails[0] ?? ""}
+      src={thumbnailSrc}
       alt={title}
     />
     <p>

--- a/src/layout/blogpost.astro
+++ b/src/layout/blogpost.astro
@@ -3,7 +3,7 @@ import { getLanguageLabel } from "../utils/languageUtils";
 import {
   buildCategoryPath,
   buildLocalizedPostPath,
-  buildResponsiveSrcSet,
+  getResponsiveImage,
   PostsTagsDefault,
 } from "../utils/postUtils";
 import { getLocale, siteConfig, toAbsoluteUrl } from "../utils/site";
@@ -37,8 +37,9 @@ const {
 const pageIcon = icon
   ? PostsTagsDefault.find((tag) => tag.value === icon)?.img ?? PostsTagsDefault[0].img
   : PostsTagsDefault[0].img;
-const socialImage = thumbnails[0] ?? images[0] ?? siteConfig.defaultSocialImage;
-const imageSrcSet = buildResponsiveSrcSet(images);
+const { src: socialImage } = getResponsiveImage([...thumbnails, ...images]);
+const { src: blogImageSrc, srcset: imageSrcSet } = getResponsiveImage(images);
+const safeSocialImage = socialImage || siteConfig.defaultSocialImage;
 const baseUrl = Astro.site?.toString() ?? siteConfig.siteUrl;
 const canonicalUrl = toAbsoluteUrl(buildLocalizedPostPath(lang, blogId), baseUrl);
 const uniqueLanguages = [...new Set(languages)] as ("en" | "es")[];
@@ -70,12 +71,12 @@ const uniqueLanguages = [...new Set(languages)] as ("en" | "es")[];
     <meta property="og:description" content={subtitle} />
     <meta property="og:type" content="article" />
     <meta property="og:url" content={canonicalUrl} />
-    <meta property="og:image" content={socialImage} />
+    <meta property="og:image" content={safeSocialImage} />
     <meta property="og:site_name" content={siteConfig.siteName} />
     <meta property="og:locale" content={getLocale(lang)} />
     <meta name="twitter:title" content={title} />
     <meta name="twitter:description" content={subtitle} />
-    <meta name="twitter:image" content={socialImage} />
+    <meta name="twitter:image" content={safeSocialImage} />
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:image:alt" content={title} />
     <title>{title}</title>
@@ -127,12 +128,12 @@ const uniqueLanguages = [...new Set(languages)] as ("en" | "es")[];
     </div>
     <div class="flex w-full flex-col px-10 pt-10 md:px-10 lg:px-20">
       {
-        images.length > 0 && (
+        blogImageSrc && (
           <div class="h-auto w-auto place-self-center">
             <img
               class="max-h-[520px] rounded-xl object-cover"
               sizes="(min-width: 1024px) 960px, 100vw"
-              src={images[0]}
+              src={blogImageSrc}
               srcset={imageSrcSet || undefined}
               alt={title}
             />

--- a/src/utils/postUtils.ts
+++ b/src/utils/postUtils.ts
@@ -113,12 +113,51 @@ export function getBlogIdFromSlug(slug: string) {
   return slug.split("/")[1] ?? "";
 }
 
+type ResponsiveSource = {
+  url: string;
+  width: number;
+};
+
+const THUMBNAIL_WIDTH_BY_HINT: Record<string, number> = {
+  thumbnail_low: 400,
+  thumbnail_med: 800,
+  thumbnail_half: 1200,
+};
+
+function inferImageWidth(url: string, index: number, total: number) {
+  const matchedHint = Object.entries(THUMBNAIL_WIDTH_BY_HINT).find(([hint]) =>
+    url.includes(hint)
+  );
+  if (matchedHint) {
+    return matchedHint[1];
+  }
+
+  // Fallback for URLs without width hint tokens.
+  const fallbackWidths = [1600, 1200, 800, 400];
+  const normalizedIndex = Math.min(index, fallbackWidths.length - 1);
+  if (total <= fallbackWidths.length) {
+    return fallbackWidths[normalizedIndex];
+  }
+  return fallbackWidths[fallbackWidths.length - 1];
+}
+
+export function buildResponsiveSources(images: string[] = []): ResponsiveSource[] {
+  const uniqueImages = [...new Set(images.filter(Boolean))];
+  return uniqueImages
+    .map((url, index) => ({
+      url,
+      width: inferImageWidth(url, index, uniqueImages.length),
+    }))
+    .sort((left, right) => left.width - right.width);
+}
+
+export function getResponsiveImage(images: string[] = []) {
+  const sources = buildResponsiveSources(images);
+  const srcset = sources.map((source) => `${source.url} ${source.width}w`).join(", ");
+  const src = sources[sources.length - 1]?.url ?? "";
+  return { src, srcset };
+}
+
 export function buildResponsiveSrcSet(images: string[] = []) {
-  const widths = [1200, 900, 600, 400];
-  return images
-    .map((image, index) => {
-      const width = widths[index] ?? widths[widths.length - 1];
-      return `${image} ${width}w`;
-    })
-    .join(", ");
+  return getResponsiveImage(images).srcset;
 }


### PR DESCRIPTION
This PR fixes responsive image handling across post cards, list rows, the blog hero image, and the site hero banner. It introduces a shared responsive image resolver that infers widths from image URL hints, sorts sources by width, and consistently picks the highest-quality fallback . The post listing and detail templates now use this shared utility so mixed image ordering no longer breaks rendered resolution selection. Overall diff: 5 files changed, 76 insertions and 27 deletions in image utilities and rendering call sites.